### PR TITLE
Alter saving of QRF model

### DIFF
--- a/improver/calibration/load_and_train_quantile_regression_random_forest.py
+++ b/improver/calibration/load_and_train_quantile_regression_random_forest.py
@@ -43,7 +43,6 @@ class LoadAndTrainQRF(PostProcessingPlugin):
         random_state: Optional[int] = None,
         transformation: Optional[str] = None,
         pre_transform_addition: float = 0,
-        compression: int = 5,
     ):
         """Initialise the LoadAndTrainQRF plugin."""
         self.feature_config = feature_config
@@ -59,7 +58,6 @@ class LoadAndTrainQRF(PostProcessingPlugin):
         self.random_state = random_state
         self.transformation = transformation
         self.pre_transform_addition = pre_transform_addition
-        self.compression = compression
         self.quantile_forest_installed = quantile_forest_package_available()
 
     def _split_cubes_and_parquet_files(
@@ -355,7 +353,7 @@ class LoadAndTrainQRF(PostProcessingPlugin):
         forecast_df = self._add_features_to_df(forecast_df, cube_inputs)
         forecast_df, truth_df = self.filter_bad_sites(forecast_df, truth_df)
 
-        TrainQuantileRegressionRandomForests(
+        result = TrainQuantileRegressionRandomForests(
             target_name=self.target_cf_name,
             feature_config=self.feature_config,
             n_estimators=self.n_estimators,
@@ -364,6 +362,6 @@ class LoadAndTrainQRF(PostProcessingPlugin):
             random_state=self.random_state,
             transformation=self.transformation,
             pre_transform_addition=self.pre_transform_addition,
-            compression=self.compression,
             model_output=model_output,
         )(forecast_df, truth_df)
+        return result

--- a/improver/calibration/quantile_regression_random_forest.py
+++ b/improver/calibration/quantile_regression_random_forest.py
@@ -6,7 +6,6 @@
 
 from typing import Optional
 
-import joblib
 import numpy as np
 import pandas as pd
 
@@ -206,8 +205,6 @@ class TrainQuantileRegressionRandomForests(BasePlugin):
         random_state: Optional[int] = None,
         transformation: Optional[str] = None,
         pre_transform_addition: np.float32 = 0,
-        compression: int = 5,
-        model_output: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialise the plugin.
@@ -246,10 +243,6 @@ class TrainQuantileRegressionRandomForests(BasePlugin):
                 Transformation to be applied to the data before fitting.
             pre_transform_addition (float):
                 Value to be added before transformation.
-            compression (int):
-                Compression level for saving the model.
-            model_output (str):
-                Full path including model file name that will store the pickled model.
             kwargs:
                 Additional keyword arguments for the quantile regression model.
 
@@ -264,8 +257,6 @@ class TrainQuantileRegressionRandomForests(BasePlugin):
         self.transformation = transformation
         _check_valid_transformation(self.transformation)
         self.pre_transform_addition = pre_transform_addition
-        self.compression = compression
-        self.output = model_output
         self.kwargs = kwargs
         self.expected_coordinate_order = ["forecast_reference_time", "forecast_period"]
 
@@ -353,9 +344,7 @@ class TrainQuantileRegressionRandomForests(BasePlugin):
         target_values = combined_df["ob_value"].values
 
         # Fit the quantile regression model
-        qrf_model = self.fit_qrf(feature_values, target_values)
-
-        joblib.dump(qrf_model, self.output, compress=self.compression)
+        return self.fit_qrf(feature_values, target_values)
 
 
 class ApplyQuantileRegressionRandomForests(PostProcessingPlugin):

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -312,6 +312,7 @@ def with_output(
     pass_through_output=False,
     compression_level=1,
     least_significant_digit: int = None,
+    output_file_type="netCDF",
     **kwargs,
 ):
     """Add `output` keyword only argument.
@@ -346,14 +347,19 @@ def with_output(
     Returns:
         Result of calling `wrapped` or None if `output` is given.
     """
+    import joblib
+
     from improver.utilities.save import save_netcdf
 
     result = wrapped(*args, **kwargs)
 
-    if output and result:
+    if output and output.endswith(".nc"):
         save_netcdf(result, output, compression_level, least_significant_digit)
         if pass_through_output:
             return ObjectAsStr(result, output)
+        return
+    elif output and output.endswith((".pickle", ".pkl")):
+        joblib.dump(result, output, compress=compression_level)
         return
     return result
 

--- a/improver/cli/train_quantile_regression_random_forest.py
+++ b/improver/cli/train_quantile_regression_random_forest.py
@@ -9,6 +9,7 @@ from improver import cli
 
 
 @cli.clizefy
+@cli.with_output
 def process(
     *file_paths: cli.inputpath,
     feature_config: cli.inputjson,
@@ -24,8 +25,6 @@ def process(
     random_state: int = None,
     transformation: str = None,
     pre_transform_addition: float = 0,
-    compression: int = 5,
-    output: str = None,
 ):
     """Training a model using Quantile Regression Random Forest.
 
@@ -92,10 +91,6 @@ def process(
             Transformation to be applied to the data before fitting.
         pre_transform_addition (float):
             Value to be added before transformation.
-        compression (int):
-            Compression level for saving the model.
-        output (str):
-            Full path including model file name that will store the pickled model.
     Returns:
         None:
             The function creates a pickle file.
@@ -119,9 +114,7 @@ def process(
         random_state=random_state,
         transformation=transformation,
         pre_transform_addition=pre_transform_addition,
-        compression=compression,
     )(
         file_paths,
-        model_output=output,
     )
     return result

--- a/improver_tests/acceptance/test_train_quantile_regression_random_forest.py
+++ b/improver_tests/acceptance/test_train_quantile_regression_random_forest.py
@@ -59,7 +59,7 @@ def test_basic(
         "5",
         "--random-state",
         "42",
-        "--compression",
+        "--compression-level",
         "5",
         "--output",
         output_path,

--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_apply_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_apply_quantile_regression_random_forest.py
@@ -78,7 +78,6 @@ def test_load_and_apply_qrf(
     feature_config = {"wind_speed_at_10m": ["mean", "std", "latitude", "longitude"]}
 
     model_output = _run_train_qrf(
-        tmp_path,
         feature_config,
         n_estimators,
         max_depth,
@@ -98,6 +97,7 @@ def test_load_and_apply_qrf(
         ],
         realization_data=[2, 6, 10],
         truth_data=[4.2, 6.2, 4.1, 5.1],
+        tmp_path=tmp_path,
     )
 
     frt = "20170103T0000Z"
@@ -182,7 +182,6 @@ def test_unexpected(
     quantiles = [0.5]
 
     model_output = _run_train_qrf(
-        tmp_path,
         feature_config,
         n_estimators,
         max_depth,
@@ -202,6 +201,7 @@ def test_unexpected(
         ],
         realization_data=[2, 6, 10],
         truth_data=[4.2, 6.2, 4.1, 5.1],
+        tmp_path=tmp_path,
     )
 
     frt = "20170103T0000Z"

--- a/improver_tests/cli/test_init.py
+++ b/improver_tests/cli/test_init.py
@@ -191,8 +191,8 @@ class Test_with_output(unittest.TestCase):
         """Tests that save_netcdf is called with object and string, default
         compression_level=1 and default least_significant_digit=None"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
-        result = wrapped_with_output.cli("argv[0]", "2", "--output=foo")
-        m.assert_called_with(4, "foo", 1, None)
+        result = wrapped_with_output.cli("argv[0]", "2", "--output=foo.nc")
+        m.assert_called_with(4, "foo.nc", 1, None)
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
@@ -200,9 +200,9 @@ class Test_with_output(unittest.TestCase):
         """Tests save_netcdf, compression-level=9 and default least-significant-digit=None"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
         result = wrapped_with_output.cli(
-            "argv[0]", "2", "--output=foo", "--compression-level=9"
+            "argv[0]", "2", "--output=foo.nc", "--compression-level=9"
         )
-        m.assert_called_with(4, "foo", 9, None)
+        m.assert_called_with(4, "foo.nc", 9, None)
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
@@ -210,9 +210,9 @@ class Test_with_output(unittest.TestCase):
         """Tests save_netcdf, compression-level=0 and default least-significant-digit=None"""
         # pylint disable is needed as it can't see the wrappers output kwarg.
         result = wrapped_with_output.cli(
-            "argv[0]", "2", "--output=foo", "--compression-level=0"
+            "argv[0]", "2", "--output=foo.nc", "--compression-level=0"
         )
-        m.assert_called_with(4, "foo", 0, None)
+        m.assert_called_with(4, "foo.nc", 0, None)
         self.assertEqual(result, None)
 
     @patch("improver.utilities.save.save_netcdf")
@@ -222,11 +222,37 @@ class Test_with_output(unittest.TestCase):
         result = wrapped_with_output.cli(
             "argv[0]",
             "2",
-            "--output=foo",
+            "--output=foo.nc",
             "--compression-level=0",
             "--least-significant-digit=2",
         )
-        m.assert_called_with(4, "foo", 0, 2)
+        m.assert_called_with(4, "foo.nc", 0, 2)
+        self.assertEqual(result, None)
+
+    @patch("joblib.dump")
+    def test_with_output_pickle(self, m):
+        """Tests that joblib.dump is called with object and string, default
+        compression_level=1 and default least_significant_digit=None"""
+        # pylint disable is needed as it can't see the wrappers output kwarg.
+        result = wrapped_with_output.cli(
+            "argv[0]",
+            "2",
+            "--output=foo.pickle",
+        )
+        m.assert_called_with(4, "foo.pickle", compress=1)
+        self.assertEqual(result, None)
+
+    @patch("joblib.dump")
+    def test_with_output_pkl(self, m):
+        """Tests that joblib.dump is called with object and string, default
+        compression_level=1 and default least_significant_digit=None"""
+        # pylint disable is needed as it can't see the wrappers output kwarg.
+        result = wrapped_with_output.cli(
+            "argv[0]",
+            "2",
+            "--output=foo.pkl",
+        )
+        m.assert_called_with(4, "foo.pkl", compress=1)
         self.assertEqual(result, None)
 
 


### PR DESCRIPTION
Related to https://github.com/metoppv/mo-blue-team/issues/877

Description
This PR alters the saving of the QRF model, so that the saving uses the clize functionality provided at the CLI level, rather than saving within the plugin.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)