### PR TITLE
Remove redundant comment in QRF unit tests

### DIFF
--- a/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
+++ b/improver_tests/calibration/quantile_regression_random_forests_calibration/test_load_and_train_quantile_regression_random_forest.py
@@ -825,7 +825,6 @@ def test_prepare_and_train_qrf(
 
     if include_site_id_nans:
         for key in site_id:
-            # As latitude is not a feature, this NaN should be ignored.
             if len(truth_df) == 1:
                 truth_df.loc[0, key] = pd.NA
             else:


### PR DESCRIPTION
Addresses https://github.com/metoppv/improver/pull/2135

Description
Remove redundant comment in the QRF unit tests.

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)

