### PR TITLE
Ensure objects containing Cubes are saved as netCDF files

### DIFF
--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -353,7 +353,13 @@ def with_output(
 
     result = wrapped(*args, **kwargs)
 
-    if output and (isinstance(result, Cube) or isinstance(result, CubeList)):
+    # If result is a Cube or CubeList or an iterable containing only Cubes,
+    # save as netCDF
+    if (
+        output
+        and (isinstance(result, (Cube, CubeList)))
+        or all([isinstance(x, Cube) for x in result])
+    ):
         save_netcdf(result, output, compression_level, least_significant_digit)
         if pass_through_output:
             return ObjectAsStr(result, output)

--- a/improver/cli/__init__.py
+++ b/improver/cli/__init__.py
@@ -357,8 +357,11 @@ def with_output(
     # save as netCDF
     if (
         output
-        and (isinstance(result, (Cube, CubeList)))
-        or all([isinstance(x, Cube) for x in result])
+        and result
+        and (
+            (isinstance(result, (Cube, CubeList)))
+            or all([isinstance(x, Cube) for x in result])
+        )
     ):
         save_netcdf(result, output, compression_level, least_significant_digit)
         if pass_through_output:

--- a/improver/psychrometric_calculations/cloud_condensation_level.py
+++ b/improver/psychrometric_calculations/cloud_condensation_level.py
@@ -45,7 +45,7 @@ class MetaCloudCondensationLevel(PostProcessingPlugin):
             model_id_attr=model_id_attr
         )
 
-    def process(self, *cubes: Union[Cube, CubeList]) -> Tuple[Cube, Cube]:
+    def process(self, *cubes: Union[Cube, CubeList]) -> CubeList[Cube, Cube]:
         """
         Call HumidityMixingRatio followed by CloudCondensationLevel to calculate cloud
         condensation level.
@@ -138,7 +138,7 @@ class CloudCondensationLevel(PostProcessingPlugin):
         ).astype(np.float32)
         return ccl_pressure, ccl_temperature
 
-    def process(self, *cubes: Union[Cube, CubeList]) -> Tuple[Cube, Cube]:
+    def process(self, *cubes: Union[Cube, CubeList]) -> CubeList[Cube, Cube]:
         """
         Calculates the cloud condensation level from the near-surface inputs.
         Values will be limited to the surface values where the calculated pressure is greater than
@@ -164,7 +164,9 @@ class CloudCondensationLevel(PostProcessingPlugin):
         mask = ccl_pressure > self.pressure.data
         ccl_pressure = np.where(mask, self.pressure.data, ccl_pressure)
         ccl_temperature = np.where(mask, self.temperature.data, ccl_temperature)
-        return (
-            self._make_ccl_cube(ccl_temperature, is_temperature=True),
-            self._make_ccl_cube(ccl_pressure, is_temperature=False),
+        return CubeList(
+            [
+                self._make_ccl_cube(ccl_temperature, is_temperature=True),
+                self._make_ccl_cube(ccl_pressure, is_temperature=False),
+            ]
         )

--- a/improver/utilities/spatial.py
+++ b/improver/utilities/spatial.py
@@ -681,7 +681,7 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
         )
         return grad_cube
 
-    def process(self, cube: Cube) -> Tuple[Cube, Cube]:
+    def process(self, cube: Cube) -> CubeList[Cube, Cube]:
         """
         Calculate the gradient along the x and y axes and return
         the result in separate cubes. The difference along each axis is
@@ -699,7 +699,7 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
               y-axis.
         """
         axis = ["x", "y"]
-        gradients = []
+        gradients = CubeList([])
         diffs = DifferenceBetweenAdjacentGridSquares()(cube)
         distances = DistanceBetweenGridSquares()(cube)
 
@@ -713,7 +713,7 @@ class GradientBetweenAdjacentGridSquares(PostProcessingPlugin):
                 grad_cube = grad_cube.regrid(cube, iris.analysis.Linear())
             gradients.append(grad_cube)
 
-        return tuple(gradients)
+        return gradients
 
 
 def maximum_within_vicinity(

--- a/improver_tests/psychrometric_calculations/cloud_condensation_level/test_CloudCondensationLevel.py
+++ b/improver_tests/psychrometric_calculations/cloud_condensation_level/test_CloudCondensationLevel.py
@@ -9,7 +9,7 @@ from typing import Tuple
 import numpy as np
 import pytest
 from iris.coords import AuxCoord
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTES
 from improver.psychrometric_calculations.cloud_condensation_level import (
@@ -125,6 +125,7 @@ def test_basic(
     humidity.data = np.full_like(humidity.data, humidity_value)
     result = CloudCondensationLevel()([temperature, pressure, humidity])
     metadata_ok(result, temperature)
+    assert isinstance(result, CubeList)
     assert np.isclose(result[0].data, expected_t, atol=1e-2).all()
     assert np.isclose(result[1].data, expected_p, atol=1e-0).all()
 

--- a/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
+++ b/improver_tests/utilities/spatial/test_GradientBetweenAdjacentGridSquares.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import pytest
+from iris.cube import CubeList
 
 from improver.metadata.constants.attributes import MANDATORY_ATTRIBUTE_DEFAULTS
 from improver.synthetic_data.set_up_test_cubes import set_up_variable_cube
@@ -135,7 +136,9 @@ def test_metadata(
     expected_x_coord = cube.coord(axis="x").copy(expected_x_points)
     expected_y_coord = cube.coord(axis="y").copy(expected_y_points)
     plugin = GradientBetweenAdjacentGridSquares(regrid=regrid)
-    result_x, result_y = plugin(cube)
+    result = plugin(cube)
+    assert isinstance(result, CubeList)
+    result_x, result_y = result
     for result, name in [(result_x, "x"), (result_y, "y")]:
         assert result.name() == f"gradient_of_air_temperature_wrt_{name}"
         assert result.units == "K m-1"


### PR DESCRIPTION
Addresses https://github.com/metoppv/improver/pull/2135

Description
This PR: 
* Updates the CloudCondensationLevel and GradientBetweenAdjacentGridSquares to return a CubeList of cubes, rather than a tuple of cubes.
* Updates `cli/__init__.py` to support the saving of an iterable containing cubes to a netCDF file, rather than a pickle file, in case there is confusion in the future if e.g. a tuple of cubes gets saved as a pickle file, rather than a netCDF file.

There are no unit tests or acceptance test failures:
```== 11630 passed, 482 skipped, 1 xpassed, 11271 warnings in 134.14s (0:02:14) ===```

Testing:

- [x] Ran tests and they passed OK
- [x] Added new tests for the new feature(s)
